### PR TITLE
Misc. fixes & improvements

### DIFF
--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -3,6 +3,8 @@
 #include <DNSServer.h>
 #include <WiFi.h>
 
+#define MAX_HTML_SIZE 20000
+
 #define B_PIN 4
 #define G_PIN 5
 #define R_PIN 6
@@ -29,7 +31,7 @@ bool name_received = false;
 bool password_received = false;
 
 char apName[30] = "PORTAL";
-char index_html[5000] = "TEST";
+char index_html[MAX_HTML_SIZE] = "TEST";
 
 // AP FUNCTIONS
 class CaptiveRequestHandler : public AsyncWebHandler {

--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -33,6 +33,9 @@ bool password_received = false;
 char apName[30] = "PORTAL";
 char index_html[MAX_HTML_SIZE] = "TEST";
 
+// RESET
+void (*resetFunction)(void) = 0;
+
 // AP FUNCTIONS
 class CaptiveRequestHandler : public AsyncWebHandler {
 public:
@@ -128,30 +131,24 @@ void getInitInput() {
   bool has_ap = false;
   bool has_html = false;
   while (!has_html || !has_ap) {
-    if (Serial.available() > 0) {
-      if(!has_html) {
-         String flipperMessage = Serial.readString();
-          const char *serialMessage = flipperMessage.c_str();
-          int compare = strncmp(serialMessage, SET_HTML_CMD, strlen(SET_HTML_CMD));
-          if (compare == 0) {
-            serialMessage += strlen(SET_HTML_CMD);
-            strncpy(index_html, serialMessage, strlen(serialMessage) - 1);
-            has_html = true;
-            Serial.println("html set");
-          }
-      } else if(!has_ap) {
+      if (Serial.available() > 0) {
         String flipperMessage = Serial.readString();
         const char *serialMessage = flipperMessage.c_str();
-        int compare = strncmp(serialMessage, SET_AP_CMD, strlen(SET_AP_CMD));
-        if (compare == 0) {
+        if (strncmp(serialMessage, SET_HTML_CMD, strlen(SET_HTML_CMD)) == 0) {
+          serialMessage += strlen(SET_HTML_CMD);
+          strncpy(index_html, serialMessage, strlen(serialMessage) - 1);
+          has_html = true;
+          Serial.println("html set");
+        } else if (strncmp(serialMessage, SET_AP_CMD, strlen(SET_AP_CMD)) ==
+                   0) {
           serialMessage += strlen(SET_AP_CMD);
           strncpy(apName, serialMessage, strlen(serialMessage) - 1);
-          has_ap = true;  
+          has_ap = true;
           Serial.println("ap set");
+        } else if (strncmp(serialMessage, RESET_CMD, strlen(RESET_CMD)) == 0) {
+          resetFunction();
         }
       }
-      
-    }
   }
   Serial.println("all set");
 }
@@ -164,8 +161,6 @@ void startPortal() {
 }
 
 // MAIN FUNCTIONS
-void (*resetFunction)(void) = 0;
-
 void setup() {
 
   // init LED pins

--- a/flipper/flipper-evil-portal/evil_portal_app.c
+++ b/flipper/flipper-evil-portal/evil_portal_app.c
@@ -28,7 +28,8 @@ Evil_PortalApp *evil_portal_app_alloc() {
 
   app->sent_html = false;
   app->sent_ap = false;
-  app->has_command_queue = false;
+  app->sent_reset = false;
+  app->has_command_queue = false;  
   app->command_index = 0;
   app->portal_logs = malloc(5000);
 
@@ -74,6 +75,7 @@ void evil_portal_app_free(Evil_PortalApp *app) {
   // save latest logs
   if (strlen(app->portal_logs) > 0) {
     write_logs(app->portal_logs);
+    free(app->portal_logs);
   }
 
   // Send reset event to dev board

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -46,6 +46,7 @@ struct Evil_PortalApp {
   bool show_stopscan_tip;
   bool sent_ap;
   bool sent_html;
+  bool sent_reset;
   int BAUDRATE;
 
   uint8_t *index_html;

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -81,6 +81,7 @@ static int32_t uart_worker(void *context) {
           strcat(uart->app->portal_logs, (char *)uart->rx_buf);
           if (strlen(uart->app->portal_logs) > 4000) {
             write_logs(uart->app->portal_logs);
+            free(uart->app->portal_logs);
           }
         }
       }

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -51,12 +51,12 @@ static int32_t uart_worker(void *context) {
         if (uart->handle_rx_data_cb) {
           uart->handle_rx_data_cb(uart->rx_buf, len, uart->app);
 
-          if (uart->app->has_command_queue) {         
-            if (uart->app->command_index < 1) {            
+          if (uart->app->has_command_queue) {
+            if (uart->app->command_index < 1) {
               if (0 ==
                   strncmp(SET_AP_CMD,
                           uart->app->command_queue[uart->app->command_index],
-                          strlen(SET_AP_CMD))) {                
+                          strlen(SET_AP_CMD))) {
                 char *out_data =
                     malloc((size_t)(strlen((char *)uart->app->ap_name) +
                                     strlen("setap=")));
@@ -78,10 +78,14 @@ static int32_t uart_worker(void *context) {
             }
           }
 
-          strcat(uart->app->portal_logs, (char *)uart->rx_buf);
+          if (uart->app->sent_reset == false) {
+            strcat(uart->app->portal_logs, (char *)uart->rx_buf);
+          }
+
           if (strlen(uart->app->portal_logs) > 4000) {
             write_logs(uart->app->portal_logs);
             free(uart->app->portal_logs);
+            strcpy(uart->app->portal_logs, "");
           }
         }
       }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -34,10 +34,11 @@ void evil_portal_read_index_html(void *context) {
     storage_file_close(index_html);
     storage_file_free(index_html);
   } else {
-    char * html_error =  "<b>Evil portal</b>\nUnable to read the html file.\n"
-                      "Is the SD Card set up correctly? See instructions\n"
-                      "github.com/bigbrodude6119/flipper-zero-evil-portal\n"
-                      "'Install pre-built app on the flipper'";
+    char *html_error =
+        "<b>Evil portal</b><br>Unable to read the html file.<br>"
+        "Is the SD Card set up correctly? <br>See instructions @ "
+        "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
+        "Under the 'Install pre-built app on the flipper' section.";
     app->index_html = (uint8_t *)html_error;
   }
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -71,7 +71,7 @@ void evil_portal_read_ap_name(void *context) {
     storage_file_close(ap_name);
     storage_file_free(ap_name);
   } else {
-    char * app_default =  "Evil Portal";
+    char *app_default = "Evil Portal";
     app->ap_name = (uint8_t *)app_default;
   }
   evil_portal_close_storage();
@@ -100,7 +100,7 @@ char *sequential_file_resolve_path(Storage *storage, const char *dir,
 void write_logs(char *portal_logs) {
   Storage *storage = evil_portal_open_storage();
 
-  if(!storage_file_exists(storage, EVIL_PORTAL_LOG_SAVE_PATH)) {
+  if (!storage_file_exists(storage, EVIL_PORTAL_LOG_SAVE_PATH)) {
     storage_simply_mkdir(storage, EVIL_PORTAL_LOG_SAVE_PATH);
   }
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -34,8 +34,10 @@ void evil_portal_read_index_html(void *context) {
     storage_file_close(index_html);
     storage_file_free(index_html);
   } else {
-    char * html_error =  "Something went wrong with reading the html file.\n"
-                      "Is the SD Card set up correctly?";
+    char * html_error =  "<b>Evil portal</b>\nUnable to read the html file.\n"
+                      "Is the SD Card set up correctly? See instructions\n"
+                      "github.com/bigbrodude6119/flipper-zero-evil-portal\n"
+                      "'Install pre-built app on the flipper'";
     app->index_html = (uint8_t *)html_error;
   }
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -97,6 +97,10 @@ char *sequential_file_resolve_path(Storage *storage, const char *dir,
 void write_logs(char *portal_logs) {
   Storage *storage = evil_portal_open_storage();
 
+  if(!storage_file_exists(storage, EVIL_PORTAL_LOG_SAVE_PATH)) {
+    storage_simply_mkdir(storage, EVIL_PORTAL_LOG_SAVE_PATH);
+  }
+
   char *seq_file_path = sequential_file_resolve_path(
       storage, EVIL_PORTAL_LOG_SAVE_PATH, "log", "txt");
 

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -54,7 +54,10 @@ void evil_portal_scene_console_output_on_enter(void *context) {
       const char *help_msg = "Logs saved.\n\n";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);
-      write_logs(app->portal_logs);
+      if(strlen(app->portal_logs) > 0) {
+        write_logs(app->portal_logs);
+        free(app->portal_logs);
+      }      
       if (app->show_stopscan_tip) {
         const char *msg = "Press BACK to return\n";
         furi_string_cat_str(app->text_box_store, msg);

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -41,8 +41,8 @@ void evil_portal_scene_console_output_on_enter(void *context) {
     if (0 == strncmp("help", app->selected_tx_string, strlen("help"))) {
       const char *help_msg =
           "BLUE = Waiting\nGREEN = Good\nRED = Bad\n\nThis project is a "
-          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n\n"
-          "Version 0.0.2";
+          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n"
+          "Version 0.0.2\n\n";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);
       if (app->show_stopscan_tip) {

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -41,7 +41,7 @@ void evil_portal_scene_console_output_on_enter(void *context) {
     if (0 == strncmp("help", app->selected_tx_string, strlen("help"))) {
       const char *help_msg =
           "BLUE = Waiting\nGREEN = Good\nRED = Bad\n\nThis project is a "
-          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n"
+          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n\n"
           "Version 0.0.2\n\n";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -41,7 +41,8 @@ void evil_portal_scene_console_output_on_enter(void *context) {
     if (0 == strncmp("help", app->selected_tx_string, strlen("help"))) {
       const char *help_msg =
           "BLUE = Waiting\nGREEN = Good\nRED = Bad\n\nThis project is a "
-          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n\n";
+          "WIP.\ngithub.com/bigbrodude6119/flipper-zero-evil-portal\n\n"
+          "Version 0.0.2";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);
       if (app->show_stopscan_tip) {

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -36,6 +36,7 @@ void evil_portal_scene_console_output_on_enter(void *context) {
   if (app->is_command) {
     furi_string_reset(app->text_box_store);
     app->text_box_store_strlen = 0;
+    app->sent_reset = false;
 
     if (0 == strncmp("help", app->selected_tx_string, strlen("help"))) {
       const char *help_msg =
@@ -54,10 +55,9 @@ void evil_portal_scene_console_output_on_enter(void *context) {
       const char *help_msg = "Logs saved.\n\n";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);
-      if(strlen(app->portal_logs) > 0) {
-        write_logs(app->portal_logs);
-        free(app->portal_logs);
-      }      
+      write_logs(app->portal_logs);
+      free(app->portal_logs);
+      strcpy(app->portal_logs, "");
       if (app->show_stopscan_tip) {
         const char *msg = "Press BACK to return\n";
         furi_string_cat_str(app->text_box_store, msg);
@@ -65,7 +65,8 @@ void evil_portal_scene_console_output_on_enter(void *context) {
       }
     }
 
-    if (0 == strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
+    if (0 ==
+        strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
       app->command_queue[0] = SET_AP_CMD;
       app->has_command_queue = true;
       app->command_index = 0;
@@ -78,6 +79,7 @@ void evil_portal_scene_console_output_on_enter(void *context) {
     }
 
     if (0 == strncmp(RESET_CMD, app->selected_tx_string, strlen(RESET_CMD))) {
+      app->sent_reset = true;
       if (app->show_stopscan_tip) {
         const char *msg = "Reseting portal\nPress BACK to return\n\n\n\n";
         furi_string_cat_str(app->text_box_store, msg);
@@ -98,7 +100,8 @@ void evil_portal_scene_console_output_on_enter(void *context) {
       app->uart, evil_portal_console_output_handle_rx_data_cb);
 
   if (app->is_command && app->selected_tx_string) {
-    if (0 == strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
+    if (0 ==
+        strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
       evil_portal_read_index_html(context);
 
       char *data = malloc(

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_start.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_start.c
@@ -34,7 +34,7 @@ const Evil_PortalItem items[NUM_MENU_ITEMS] = {
      1,
      {SET_HTML_CMD},
      NO_ARGS,
-     FOCUS_CONSOLE_START,
+     FOCUS_CONSOLE_END,
      SHOW_STOPSCAN_TIP},
 
     // stop portal


### PR DESCRIPTION
This PR contains the following fixes:

1. The log folder will now be created if it does not exist on the SD card. This prevents the user from losing log data.
2. Logs no longer contain output from the reset command.
3. Log variable  is cleared every time logs are saved.
4. Fixed an issue where the user could not start the portal if the HTML was set but an error occurred before the AP was set.

Improvements:

1. The size limit for the index_html array is now 20k. This should help create more advanced portals.
2. Added more information to the html read error & help command.
3. Auto-scroll to bottom of the "Start Portal" output logs. 