### PR TITLE
Fix: continue logging when not in portal start scene

### DIFF
--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -137,14 +137,12 @@ void getInitInput() {
         if (strncmp(serialMessage, SET_HTML_CMD, strlen(SET_HTML_CMD)) == 0) {
           serialMessage += strlen(SET_HTML_CMD);
           strncpy(index_html, serialMessage, strlen(serialMessage) - 1);
-          strcat(index_html, "\0");
           has_html = true;
           Serial.println("html set");
         } else if (strncmp(serialMessage, SET_AP_CMD, strlen(SET_AP_CMD)) ==
                    0) {
           serialMessage += strlen(SET_AP_CMD);
           strncpy(apName, serialMessage, strlen(serialMessage) - 1);
-          strcat(apName, "\0");
           has_ap = true;
           Serial.println("ap set");
         } else if (strncmp(serialMessage, RESET_CMD, strlen(RESET_CMD)) == 0) {

--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -137,12 +137,14 @@ void getInitInput() {
         if (strncmp(serialMessage, SET_HTML_CMD, strlen(SET_HTML_CMD)) == 0) {
           serialMessage += strlen(SET_HTML_CMD);
           strncpy(index_html, serialMessage, strlen(serialMessage) - 1);
+          strcat(index_html, "\0");
           has_html = true;
           Serial.println("html set");
         } else if (strncmp(serialMessage, SET_AP_CMD, strlen(SET_AP_CMD)) ==
                    0) {
           serialMessage += strlen(SET_AP_CMD);
           strncpy(apName, serialMessage, strlen(serialMessage) - 1);
+          strcat(apName, "\0");
           has_ap = true;
           Serial.println("ap set");
         } else if (strncmp(serialMessage, RESET_CMD, strlen(RESET_CMD)) == 0) {

--- a/flipper/flipper-evil-portal/evil_portal_app.c
+++ b/flipper/flipper-evil-portal/evil_portal_app.c
@@ -113,7 +113,6 @@ int32_t evil_portal_app(void *p) {
 
   view_dispatcher_run(evil_portal_app->view_dispatcher);  
 
-  // crashing here
   evil_portal_app_free(evil_portal_app);
 
   return 0;

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -87,8 +87,19 @@ static int32_t uart_worker(void *context) {
             free(uart->app->portal_logs);
             strcpy(uart->app->portal_logs, "");
           }
+        } else {          
+          uart->rx_buf[len] = '\0';
+          if (uart->app->sent_reset == false) {
+            strcat(uart->app->portal_logs, (char *)uart->rx_buf);
+          }
+
+          if (strlen(uart->app->portal_logs) > 4000) {
+            write_logs(uart->app->portal_logs);
+            free(uart->app->portal_logs);
+            strcpy(uart->app->portal_logs, "");
+          }
         }
-      }
+      } 
     }
   }
 


### PR DESCRIPTION
UART events from the dev board to the flipper are lost while in the main menu, this results in a possible loss of data.
This fix adds an event that appends to the portal_logs variable when there is no UART callback present.