### PR TITLE
Fix junk characters in ap name and HTML page

### DIFF
--- a/flipper/flipper-evil-portal/evil_portal_app.c
+++ b/flipper/flipper-evil-portal/evil_portal_app.c
@@ -1,8 +1,6 @@
+#include <furi.h>
 #include "evil_portal_app_i.h"
 #include "helpers/evil_portal_storage.h"
-
-#include <furi.h>
-#include <furi_hal.h>
 
 static bool evil_portal_app_custom_event_callback(void *context,
                                                   uint32_t event) {
@@ -34,6 +32,7 @@ Evil_PortalApp *evil_portal_app_alloc() {
   app->portal_logs = furi_string_alloc();
 
   app->gui = furi_record_open(RECORD_GUI);
+  app->storage = furi_record_open(RECORD_STORAGE);
 
   app->view_dispatcher = view_dispatcher_alloc();
   app->scene_manager = scene_manager_alloc(&evil_portal_scene_handlers, app);
@@ -74,7 +73,7 @@ void evil_portal_app_free(Evil_PortalApp *app) {
 
   // save latest logs
   if (furi_string_utf8_length(app->portal_logs) > 0) {
-    write_logs(app->portal_logs);
+    write_logs(app->storage, app->portal_logs);
     furi_string_free(app->portal_logs);
   }
 
@@ -101,6 +100,7 @@ void evil_portal_app_free(Evil_PortalApp *app) {
 
   // Close records
   furi_record_close(RECORD_GUI);
+  furi_record_close(RECORD_STORAGE);
 
   free(app);
 }

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -10,6 +10,7 @@
 #include <gui/modules/variable_item_list.h>
 #include <gui/scene_manager.h>
 #include <gui/view_dispatcher.h>
+#include <storage/storage.h>
 
 #define NUM_MENU_ITEMS (4)
 
@@ -24,6 +25,7 @@ struct Evil_PortalApp {
   Gui *gui;
   ViewDispatcher *view_dispatcher;
   SceneManager *scene_manager;
+  Storage *storage;
 
   FuriString* portal_logs;
   const char *command_queue[1];

--- a/flipper/flipper-evil-portal/evil_portal_app_i.h
+++ b/flipper/flipper-evil-portal/evil_portal_app_i.h
@@ -48,9 +48,6 @@ struct Evil_PortalApp {
   bool sent_html;
   bool sent_reset;
   int BAUDRATE;
-
-  uint8_t *index_html;
-  uint8_t *ap_name;
 };
 
 typedef enum {

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -59,9 +59,7 @@ static int32_t uart_worker(void *context) {
                           uart->app->command_queue[uart->app->command_index],
                           strlen(SET_AP_CMD))) {
 
-                Storage *storage = evil_portal_open_storage();
-                uart->app->sent_ap = evil_portal_set_ap_name(storage);
-                evil_portal_close_storage();
+                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->storage);
               }
 
               uart->app->command_index = 0;
@@ -75,7 +73,7 @@ static int32_t uart_worker(void *context) {
           }
 
           if (furi_string_utf8_length(uart->app->portal_logs) > 4000) {
-            write_logs(uart->app->portal_logs);
+            write_logs(uart->app->storage, uart->app->portal_logs);
             furi_string_reset(uart->app->portal_logs);
           }
         } else {          
@@ -85,7 +83,7 @@ static int32_t uart_worker(void *context) {
           }
 
           if (furi_string_utf8_length(uart->app->portal_logs) > 4000) {
-            write_logs(uart->app->portal_logs);
+            write_logs(uart->app->storage, uart->app->portal_logs);
             furi_string_reset(uart->app->portal_logs);
           }
         }

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -1,6 +1,7 @@
 #include "evil_portal_app_i.h"
 #include "evil_portal_uart.h"
 #include "helpers/evil_portal_storage.h"
+#include "helpers/evil_portal_commands.h"
 
 struct Evil_PortalUart {
   Evil_PortalApp *app;
@@ -57,19 +58,10 @@ static int32_t uart_worker(void *context) {
                   strncmp(SET_AP_CMD,
                           uart->app->command_queue[uart->app->command_index],
                           strlen(SET_AP_CMD))) {
-                FuriString *out_data = furi_string_alloc();
 
-                furi_string_cat(out_data, "setap=");
-                furi_string_cat(out_data, (char *)uart->app->ap_name);
-
-                evil_portal_uart_tx((uint8_t *)(furi_string_get_cstr(out_data)),
-                                    strlen(furi_string_get_cstr(out_data)));
-                evil_portal_uart_tx((uint8_t *)("\n"), 1);
-
-                uart->app->sent_ap = true;
-
-                free(out_data);
-                free(uart->app->ap_name);
+                Storage *storage = evil_portal_open_storage();
+                uart->app->sent_ap = evil_portal_set_ap_name(storage);
+                evil_portal_close_storage();
               }
 
               uart->app->command_index = 0;

--- a/flipper/flipper-evil-portal/evil_portal_uart.c
+++ b/flipper/flipper-evil-portal/evil_portal_uart.c
@@ -59,7 +59,7 @@ static int32_t uart_worker(void *context) {
                           uart->app->command_queue[uart->app->command_index],
                           strlen(SET_AP_CMD))) {
 
-                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->storage);
+                uart->app->sent_ap = evil_portal_set_ap_name(uart->app->storage, EVIL_PORTAL_AP_SAVE_PATH);
               }
 
               uart->app->command_index = 0;

--- a/flipper/flipper-evil-portal/evil_portal_uart.h
+++ b/flipper/flipper-evil-portal/evil_portal_uart.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "furi_hal.h"
+#include "evil_portal_app.h"
 
 #define RX_BUF_SIZE (320)
 

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -32,7 +32,6 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
     furi_assert(storage, "storage is null");
     furi_assert(path, "the html file path is null");
 
-    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "sethtml=", 8);
 
     bool html_sent = send_file_over_uart(storage, path);
@@ -45,7 +44,6 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
         evil_portal_uart_tx((uint8_t*) error_message, strlen(error_message));
     }
 
-    // Send the commands terminator.
     evil_portal_uart_tx((uint8_t*) "\n", 1);
 
     return true;
@@ -55,7 +53,6 @@ bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
     furi_assert(storage, "storage is null");
     furi_assert(ap_config_path, "the ap config path is null");
 
-    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "setap=", 6);
 
     bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
@@ -65,7 +62,6 @@ bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
         evil_portal_uart_tx((uint8_t*) default_name, strlen(default_name));
     }
 
-    // Send the commands terminator.
     evil_portal_uart_tx((uint8_t*) "\n", 1);
     return true;
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -1,0 +1,73 @@
+#include <stream/stream.h>
+#include <stream/buffered_file_stream.h>
+#include "../evil_portal_uart.h"
+
+#define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
+#define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
+
+static const char TAG[] = "evil_portal_command";
+
+static bool send_file_over_uart(Storage *storage, const char* path) {
+    Stream *file_stream = buffered_file_stream_alloc(storage);
+    if (!buffered_file_stream_open(file_stream, path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+        FURI_LOG_E(TAG, "Unable to open stream: %s", path);
+        // The stream should be closed also if the open fails.
+        buffered_file_stream_close(file_stream);
+        return false;
+    }
+
+    uint8_t read_buffer[128];
+    size_t to_read_bytes = stream_size(file_stream);
+
+    while(to_read_bytes > 0) {
+        size_t byte_read = stream_read(file_stream, read_buffer, sizeof read_buffer);
+        evil_portal_uart_tx(read_buffer, byte_read);
+
+        to_read_bytes -= byte_read;
+    }
+
+    buffered_file_stream_close(file_stream);
+
+    return true;
+}
+
+bool evil_portal_set_html(Storage *storage, const char* path) {
+    furi_assert(storage, "storage is null");
+    furi_assert(path, "the html file path is null");
+
+    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
+    evil_portal_uart_tx((uint8_t*) "sethtml=", 8);
+
+    bool html_sent = send_file_over_uart(storage, path);
+
+    if (!html_sent) {
+        char *error_message = "<b>Evil portal</b><br>Unable to read the html file.<br>"
+                              "Is the SD Card set up correctly? <br>See instructions @ "
+                              "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
+                              "Under the 'Install pre-built app on the flipper' section.";
+        evil_portal_uart_tx((uint8_t*) error_message, strlen(error_message));
+    }
+
+    // Send the commands terminator.
+    evil_portal_uart_tx((uint8_t*) "\n", 1);
+
+    return true;
+}
+
+bool evil_portal_set_ap_name(Storage *storage) {
+    furi_assert(storage, "storage is null");
+
+    // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
+    evil_portal_uart_tx((uint8_t*) "setap=", 6);
+
+    bool ap_name_sent = send_file_over_uart(storage, EVIL_PORTAL_AP_SAVE_PATH);
+
+    if (!ap_name_sent) {
+        char *default_name = "Evil Portal";
+        evil_portal_uart_tx((uint8_t*) default_name, strlen(default_name));
+    }
+
+    // Send the commands terminator.
+    evil_portal_uart_tx((uint8_t*) "\n", 1);
+    return true;
+}

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.c
@@ -2,10 +2,7 @@
 #include <stream/buffered_file_stream.h>
 #include "../evil_portal_uart.h"
 
-#define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
-#define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
-
-static const char TAG[] = "evil_portal_command";
+#define TAG "evil_portal_command"
 
 static bool send_file_over_uart(Storage *storage, const char* path) {
     Stream *file_stream = buffered_file_stream_alloc(storage);
@@ -54,13 +51,14 @@ bool evil_portal_set_html(Storage *storage, const char* path) {
     return true;
 }
 
-bool evil_portal_set_ap_name(Storage *storage) {
+bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path) {
     furi_assert(storage, "storage is null");
+    furi_assert(ap_config_path, "the ap config path is null");
 
     // Start the html set sending to the esp the command, use -1 to exclude the string terminator bytes.
     evil_portal_uart_tx((uint8_t*) "setap=", 6);
 
-    bool ap_name_sent = send_file_over_uart(storage, EVIL_PORTAL_AP_SAVE_PATH);
+    bool ap_name_sent = send_file_over_uart(storage, ap_config_path);
 
     if (!ap_name_sent) {
         char *default_name = "Evil Portal";

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -1,19 +1,18 @@
 #pragma once
 
 /**
- * Sends the provided evil portal index file to the ESP32.
- * @param storage - Storage instance.
- * @param path - Path of the index that will be sent to the ESP32.
- * @return Returns true if the file has been sent correctly, false otherwise.
+ * Sends the specified evil portal index file to the ESP32.
+ * @param storage - The storage instance to use.
+ * @param path - The path of the index file that will be sent to the ESP32.
+ * @return Returns true if the file has been sent successfully, false otherwise.
  */
 bool evil_portal_set_html(Storage *storage, const char *path);
 
 /**
- * Reads the access point name from the storage and then send it to the
- * ESP32.
- * @param storage - Storage instance.
- * @param ap_config_path - Path of the configuration file that contains the ap name
- * that will be sent to the ESP32.
- * @return Returns true if ap name has been sent to correctly, false otherwise.
+ * Reads the access point name from the storage and sends it to the ESP32.
+ * @param storage - The storage instance to use.
+ * @param ap_config_path - The path of the configuration file that contains the access point (AP) name
+ * to be sent to the ESP32.
+ * @return Returns true if the AP name has been sent correctly, false otherwise.
  */
 bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -6,12 +6,14 @@
  * @param path - Path of the index that will be sent to the ESP32.
  * @return Returns true if the file has been sent correctly, false otherwise.
  */
-bool evil_portal_set_html(Storage *storage, const char* path);
+bool evil_portal_set_html(Storage *storage, const char *path);
 
 /**
  * Reads the access point name from the storage and then send it to the
  * ESP32.
  * @param storage - Storage instance.
+ * @param ap_config_path - Path of the configuration file that contains the ap name
+ * that will be sent to the ESP32.
  * @return Returns true if ap name has been sent to correctly, false otherwise.
  */
-bool evil_portal_set_ap_name(Storage *storage);
+bool evil_portal_set_ap_name(Storage *storage, const char *ap_config_path);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_commands.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * Sends the provided evil portal index file to the ESP32.
+ * @param storage - Storage instance.
+ * @param path - Path of the index that will be sent to the ESP32.
+ * @return Returns true if the file has been sent correctly, false otherwise.
+ */
+bool evil_portal_set_html(Storage *storage, const char* path);
+
+/**
+ * Reads the access point name from the storage and then send it to the
+ * ESP32.
+ * @param storage - Storage instance.
+ * @return Returns true if ap name has been sent to correctly, false otherwise.
+ */
+bool evil_portal_set_ap_name(Storage *storage);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -1,12 +1,6 @@
 #include "evil_portal_storage.h"
 
-Storage *evil_portal_open_storage() {
-  return furi_record_open(RECORD_STORAGE);
-}
-
-void evil_portal_close_storage() { furi_record_close(RECORD_STORAGE); }
-
-char *sequential_file_resolve_path(Storage *storage, const char *dir,
+static char *sequential_file_resolve_path(Storage *storage, const char *dir,
                                    const char *prefix, const char *extension) {
   if (storage == NULL || dir == NULL || prefix == NULL || extension == NULL) {
     return NULL;
@@ -26,9 +20,7 @@ char *sequential_file_resolve_path(Storage *storage, const char *dir,
   return strdup(file_path);
 }
 
-void write_logs(FuriString *portal_logs) {
-  Storage *storage = evil_portal_open_storage();
-
+void write_logs(Storage *storage, FuriString *portal_logs) {
   if (!storage_file_exists(storage, EVIL_PORTAL_LOG_SAVE_PATH)) {
     storage_simply_mkdir(storage, EVIL_PORTAL_LOG_SAVE_PATH);
   }
@@ -43,5 +35,4 @@ void write_logs(FuriString *portal_logs) {
   }
   storage_file_close(file);
   storage_file_free(file);
-  evil_portal_close_storage();
 }

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.c
@@ -1,81 +1,10 @@
 #include "evil_portal_storage.h"
 
-static Storage *evil_portal_open_storage() {
+Storage *evil_portal_open_storage() {
   return furi_record_open(RECORD_STORAGE);
 }
 
-static void evil_portal_close_storage() { furi_record_close(RECORD_STORAGE); }
-
-void evil_portal_read_index_html(void *context) {
-
-  Evil_PortalApp *app = context;
-  Storage *storage = evil_portal_open_storage();
-  FileInfo fi;
-
-  if (storage_common_stat(storage, EVIL_PORTAL_INDEX_SAVE_PATH, &fi) ==
-      FSE_OK) {
-    File *index_html = storage_file_alloc(storage);
-    if (storage_file_open(index_html, EVIL_PORTAL_INDEX_SAVE_PATH, FSAM_READ,
-                          FSOM_OPEN_EXISTING)) {
-      app->index_html = malloc((size_t)fi.size);
-      uint8_t *buf_ptr = app->index_html;
-      size_t read = 0;
-      while (read < fi.size) {
-        size_t to_read = fi.size - read;
-        if (to_read > UINT16_MAX)
-          to_read = UINT16_MAX;
-        uint16_t now_read =
-            storage_file_read(index_html, buf_ptr, (uint16_t)to_read);
-        read += now_read;
-        buf_ptr += now_read;
-      }
-      free(buf_ptr);
-    }
-    storage_file_close(index_html);
-    storage_file_free(index_html);
-  } else {
-    char *html_error =
-        "<b>Evil portal</b><br>Unable to read the html file.<br>"
-        "Is the SD Card set up correctly? <br>See instructions @ "
-        "github.com/bigbrodude6119/flipper-zero-evil-portal<br>"
-        "Under the 'Install pre-built app on the flipper' section.";
-    app->index_html = (uint8_t *)html_error;
-  }
-
-  evil_portal_close_storage();
-}
-
-void evil_portal_read_ap_name(void *context) {
-  Evil_PortalApp *app = context;
-  Storage *storage = evil_portal_open_storage();
-  FileInfo fi;
-
-  if (storage_common_stat(storage, EVIL_PORTAL_AP_SAVE_PATH, &fi) == FSE_OK) {
-    File *ap_name = storage_file_alloc(storage);
-    if (storage_file_open(ap_name, EVIL_PORTAL_AP_SAVE_PATH, FSAM_READ,
-                          FSOM_OPEN_EXISTING)) {
-      app->ap_name = malloc((size_t)fi.size);
-      uint8_t *buf_ptr = app->ap_name;
-      size_t read = 0;
-      while (read < fi.size) {
-        size_t to_read = fi.size - read;
-        if (to_read > UINT16_MAX)
-          to_read = UINT16_MAX;
-        uint16_t now_read =
-            storage_file_read(ap_name, buf_ptr, (uint16_t)to_read);
-        read += now_read;
-        buf_ptr += now_read;
-      }
-      free(buf_ptr);
-    }
-    storage_file_close(ap_name);
-    storage_file_free(ap_name);
-  } else {
-    char *app_default = "Evil Portal";
-    app->ap_name = (uint8_t *)app_default;
-  }
-  evil_portal_close_storage();
-}
+void evil_portal_close_storage() { furi_record_close(RECORD_STORAGE); }
 
 char *sequential_file_resolve_path(Storage *storage, const char *dir,
                                    const char *prefix, const char *extension) {

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -1,17 +1,9 @@
-#include "../evil_portal_app_i.h"
-#include <flipper_format/flipper_format_i.h>
-#include <lib/toolbox/stream/file_stream.h>
-#include <stdlib.h>
+#include <furi.h>
 #include <storage/storage.h>
-#include <string.h>
 
 #define PORTAL_FILE_DIRECTORY_PATH EXT_PATH("apps_data/evil_portal")
 #define EVIL_PORTAL_INDEX_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/index.html"
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
-Storage *evil_portal_open_storage();
-void evil_portal_close_storage();
-void write_logs(FuriString* portal_logs);
-char *sequential_file_resolve_path(Storage *storage, const char *dir,
-                                   const char *prefix, const char *extension);
+void write_logs(Storage *storage, FuriString* portal_logs);

--- a/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
+++ b/flipper/flipper-evil-portal/helpers/evil_portal_storage.h
@@ -10,8 +10,8 @@
 #define EVIL_PORTAL_AP_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/ap.config.txt"
 #define EVIL_PORTAL_LOG_SAVE_PATH PORTAL_FILE_DIRECTORY_PATH "/logs"
 
-void evil_portal_read_index_html(void *context);
-void evil_portal_read_ap_name(void *context);
+Storage *evil_portal_open_storage();
+void evil_portal_close_storage();
 void write_logs(FuriString* portal_logs);
 char *sequential_file_resolve_path(Storage *storage, const char *dir,
                                    const char *prefix, const char *extension);

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -1,5 +1,6 @@
 #include "../evil_portal_app_i.h"
 #include "../helpers/evil_portal_storage.h"
+#include "../helpers/evil_portal_commands.h"
 
 void evil_portal_console_output_handle_rx_data_cb(uint8_t *buf, size_t len,
                                                   void *context) {
@@ -102,22 +103,10 @@ void evil_portal_scene_console_output_on_enter(void *context) {
   if (app->is_command && app->selected_tx_string) {
     if (0 ==
         strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
-      evil_portal_read_index_html(context);
 
-      FuriString *data = furi_string_alloc();
-      furi_string_cat(data, "sethtml=");
-      furi_string_cat(data, (char *)app->index_html);
-
-      evil_portal_uart_tx((uint8_t *)(furi_string_get_cstr(data)),
-                          strlen(furi_string_get_cstr(data)));
-      evil_portal_uart_tx((uint8_t *)("\n"), 1);
-
-      app->sent_html = true;
-
-      free(data);
-      free(app->index_html);
-
-      evil_portal_read_ap_name(context);
+      Storage *storage = evil_portal_open_storage();
+      app->sent_html = evil_portal_set_html(storage, EVIL_PORTAL_INDEX_SAVE_PATH);
+      evil_portal_close_storage();
     } else if (0 ==
                strncmp(RESET_CMD, app->selected_tx_string, strlen(RESET_CMD))) {
       app->sent_html = false;

--- a/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
+++ b/flipper/flipper-evil-portal/scenes/evil_portal_scene_console_output.c
@@ -57,7 +57,7 @@ void evil_portal_scene_console_output_on_enter(void *context) {
       const char *help_msg = "Logs saved.\n\n";
       furi_string_cat_str(app->text_box_store, help_msg);
       app->text_box_store_strlen += strlen(help_msg);
-      write_logs(app->portal_logs);
+      write_logs(app->storage, app->portal_logs);
       furi_string_reset(app->portal_logs);
       if (app->show_stopscan_tip) {
         const char *msg = "Press BACK to return\n";
@@ -104,9 +104,7 @@ void evil_portal_scene_console_output_on_enter(void *context) {
     if (0 ==
         strncmp(SET_HTML_CMD, app->selected_tx_string, strlen(SET_HTML_CMD))) {
 
-      Storage *storage = evil_portal_open_storage();
-      app->sent_html = evil_portal_set_html(storage, EVIL_PORTAL_INDEX_SAVE_PATH);
-      evil_portal_close_storage();
+      app->sent_html = evil_portal_set_html(app->storage, EVIL_PORTAL_INDEX_SAVE_PATH);
     } else if (0 ==
                strncmp(RESET_CMD, app->selected_tx_string, strlen(RESET_CMD))) {
       app->sent_html = false;


### PR DESCRIPTION
Fix: #26 

This PR resolves a bug that caused the display of junk characters in the HTML page and in the AP name. The issue was triggered by performing `free` on the pointer that stored the HTML page and the AP name after they were read, see [here](https://github.com/bigbrodude6119/flipper-zero-evil-portal/blob/d196f60fe8b40f21b6aa296483c03494daf1f946/flipper/flipper-evil-portal/helpers/evil_portal_storage.c#L32C21-L32C21) for the HTML page and [here](https://github.com/bigbrodude6119/flipper-zero-evil-portal/blob/d196f60fe8b40f21b6aa296483c03494daf1f946/flipper/flipper-evil-portal/helpers/evil_portal_storage.c#L69) for the AP name.  
To fix this bug and avoid reading the entire HTML file into the heap, the HTML page and the AP name are now read in chunks of 128 bytes and then sent to the ESP32. This approach prevents memory-related issues and ensures the correct visualization of data on the HTML page and the AP name